### PR TITLE
Allow the use of minDate

### DIFF
--- a/lib/Datepicker.js
+++ b/lib/Datepicker.js
@@ -95,7 +95,7 @@ var Datepicker = function (_Component) {
           }
         },
         _react2.default.createElement('input', { name: this.props.datepickerName, className: this.props.datepickerClassName, id: this.props.datepickerId, onFocus: this.handleCalendarVisibility, value: (0, _format2.default)(this.state.selectedDate, this.props.dateFormat), readOnly: true }),
-        this.state.showCalendar && _react2.default.createElement(_Calendar2.default, { startDate: this.state.selectedDate, dateChange: this.dateChange })
+        this.state.showCalendar && _react2.default.createElement(_Calendar2.default, { startDate: this.state.selectedDate, dateChange: this.dateChange, minDate: this.props.minDate })
       );
     }
   }]);

--- a/src/Datepicker.js
+++ b/src/Datepicker.js
@@ -53,7 +53,7 @@ export default class Datepicker extends Component {
       >
         <input name={this.props.datepickerName} className={this.props.datepickerClassName} id={this.props.datepickerId} onFocus={this.handleCalendarVisibility} value={format(this.state.selectedDate, this.props.dateFormat)} readOnly />
 
-        {this.state.showCalendar && <Calendar startDate={this.state.selectedDate} dateChange={this.dateChange} />}
+        {this.state.showCalendar && <Calendar startDate={this.state.selectedDate} dateChange={this.dateChange} minDate={this.props.minDate} />}
       </div>
     )
   }


### PR DESCRIPTION
minDate is documented as a prop of Datepicker while it wasn't passed to the calendar, making selection of past dates impossible.